### PR TITLE
Add json schema variant for json path DSL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,36 +1,37 @@
 [package]
 name = "grillon"
-version = "0.4.0"
+version = "0.5.0-alpha.1"
 authors = ["theredfish <did.julian@gmail.com>"]
 description = "Grillon offers an elegant and natural way to approach API testing in Rust."
 repository = "https://github.com/owlduty/grillon"
-keywords = ["test", "http", "e2e", "end-to-end"]
+keywords = ["test", "http", "api", "e2e"]
 categories = ["development-tools::testing"]
 readme = "README.md"
 license = "MIT OR Apache-2.0"
-include = [
-  "/src",
-  "LICENSE*",
-  "README.md"
-]
+include = ["/src", "LICENSE*", "README.md"]
 edition = "2021"
 
 [dependencies]
-hyper = { version = "0.14.26", features = ["client", "http1", "http2", "runtime"] }
+hyper = { version = "0.14.27", features = [
+  "client",
+  "http1",
+  "http2",
+  "runtime",
+] }
 hyper-tls = "0.5.0"
-serde = { version = "1.0.163", features = ["derive"] }
-serde_json = "1.0.96"
+serde = { version = "1.0.188", features = ["derive"] }
+serde_json = "1.0.105"
 http = "0.2.9"
-url = "2.3.1"
+url = "2.4.1"
 futures = "0.3.28"
 strum = { version = "0.25.0", features = ["derive"] }
-strum_macros = "0.25.0"
-jsonpath-rust = "0.3.0"
-jsonschema = "0.17.0"
+strum_macros = "0.25.2"
+jsonpath-rust = "0.3.1"
+jsonschema = "0.17.1"
 
 [dev-dependencies]
-tokio = { version = "1.28.1", features = ["macros"] }
-reqwest = { version = "0.11.18", features = ["json"] }
-httpmock = "0.6.7"
-async-trait = "0.1.68"
+tokio = { version = "1.32.0", features = ["macros"] }
+reqwest = { version = "0.11.20", features = ["json"] }
+httpmock = "0.6.8"
+async-trait = "0.1.73"
 test-case = "3.1.0"

--- a/README.md
+++ b/README.md
@@ -21,13 +21,14 @@ Grillon offers an elegant and natural way to approach API testing in Rust.
 
 ## Getting started
 
-This example uses [Tokio](https://tokio.rs/) as asynchronous runtime. Generally, testing libs are used in unit or integration tests. You can declare `grillon` as a dev-dependency.
+This example uses [Tokio](https://tokio.rs/) as asynchronous runtime. Generally, testing libs are
+used in unit or integration tests. You can declare `grillon` as a dev-dependency.
 
 Add `grillon` to `Cargo.toml`
 
 ```toml
 [dev-dependencies]
-grillon = "0.4.0"
+grillon = "0.5.0-alpha.1"
 tokio = { version = "1", features = ["macros"] }
 ```
 

--- a/book/src/writing_tests/assertions.md
+++ b/book/src/writing_tests/assertions.md
@@ -26,10 +26,10 @@ conditions, it's possible. Each assertion produces [logs](../logs.md).
 |headers      |is, is_not, contains, does_not_contain|Vec<(HeaderName, HeaderValue)>, HeaderMap|
 |status       |is, is_not, is_between                |u16, StatusCode                          |
 |json_body    |is, is_not, schema                    |String, &str, Value, `json!`             |
-|json_path    |is, is_not                            |Value, `json!`                           |
+|json_path    |is, is_not, schema                    |Value, `json!`                           |
 |response_time|is_less_than                          |u64                                      |
 
-### Note about json path
+### Note about `json_path`
 
 Json path requires one more argument than other predicates because you have to provide a path. The
 expected value should always be a json document. To enforce this, we require a `Value` that you can
@@ -50,6 +50,16 @@ async fn test_json_path() -> Result<()> {
     Ok(())
 }
 ```
+
+### Note about `schema`
+
+The `schema` predicate can be used with both `json_body` and `json_path` parts. Although the
+available types differ between them, the `schema` predicate signature is independent and can be used
+with the following types:
+
+- &str
+- String
+- Value (you can also use the `json!` macro)
 
 ## Custom assertions
 

--- a/tests/assert/json_path.rs
+++ b/tests/assert/json_path.rs
@@ -26,7 +26,6 @@ async fn json_path_should_be_equal_failure_bad_data() {
     let mock_server = HttpMockServer::new();
     mock_server.get_valid_user();
 
-    let path = "$";
     let expected_json = json!({
         "id": 1,
         "name": "Max",
@@ -37,7 +36,7 @@ async fn json_path_should_be_equal_failure_bad_data() {
         .get("users/1")
         .assert()
         .await
-        .json_path(path, is(expected_json));
+        .json_path("$", is(expected_json));
 }
 
 #[tokio::test]
@@ -46,7 +45,6 @@ async fn json_path_should_be_equal_failure_no_data() {
     let mock_server = HttpMockServer::new();
     mock_server.get_valid_user();
 
-    let path = "$.lastname";
     let expected_json = json!({
         "id": 1,
         "name": "Isaac",
@@ -57,7 +55,7 @@ async fn json_path_should_be_equal_failure_no_data() {
         .get("users/1")
         .assert()
         .await
-        .json_path(path, is(expected_json));
+        .json_path("$.lastname", is(expected_json));
 }
 
 #[tokio::test]
@@ -65,7 +63,6 @@ async fn json_path_should_not_be_equal() -> Result<()> {
     let mock_server = HttpMockServer::new();
     let mock = mock_server.get_valid_user();
 
-    let path = "$";
     let json = json!({
         "id": 2,
         "name": "Max",
@@ -75,7 +72,7 @@ async fn json_path_should_not_be_equal() -> Result<()> {
         .get("users/1")
         .assert()
         .await
-        .json_path(path, is_not(json));
+        .json_path("$", is_not(json));
 
     mock.assert();
 


### PR DESCRIPTION
Now the value for a given json path can be checked with this high order function: `json_path("$.id", schema(json_schema))`.

Fix #9